### PR TITLE
feat: add @immutable annotation emitting CEL XValidation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,44 @@ size: "medium"
 - **Pointers**: `{*type}` or `{?type}` (equivalent)
 - **Default values**: `fieldName=value` or `fieldName="value"`
 
+### Validation constraints
+
+Stack these tags on the line(s) after a `@param` or `@field`. They emit kubebuilder validation markers on the generated Go struct and JSON-schema entries in `values.schema.json`.
+
+```yaml
+## @param {int} port - Port number
+## @minimum 1
+## @maximum 65535
+port: 8080
+
+## @param {string} name - DNS-compatible name
+## @minLength 1
+## @maxLength 63
+## @pattern ^[a-z0-9-]+$
+name: ""
+
+## @param {[]string} tags - Tag list
+## @minItems 1
+## @maxItems 10
+tags: []
+
+## @param {string} storageClass - StorageClass used to store the data.
+## @immutable
+storageClass: ""
+```
+
+Available constraints: `@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`, `@minLength`, `@maxLength`, `@pattern`, `@minItems`, `@maxItems`, `@immutable`.
+
+**Placement matters.** Every constraint attaches to the most-recent `@param` or `@field` declaration. Place constraints **immediately after** the `@param`/`@field` header and **before** the YAML value line. If a constraint appears after the YAML value (e.g. floating between two `@param` blocks), it still attaches to the preceding `@param` for backwards compatibility, but `cozyvalues-gen` prints
+
+```
+cozyvalues-gen: <file>:<line>: warning: constraint on this line still attaches to "<field>" across an intervening YAML value line; move it to immediately after the @param/@field header for clarity
+```
+
+so the misplacement is visible in `make generate` output. The warning never fails the build — fix the placement to silence it.
+
+`@immutable` is a flag (no argument). It emits a CEL `XValidation` rule (`self == oldSelf`) at the property level. **Caveat**: per Kubernetes `x-kubernetes-validations` semantics, a property-level rule is evaluated only when the property is present in both `oldSelf` and `self`. For optional/omitempty/pointer fields the rule therefore enforces *immutable once set* rather than *immutable from creation* — the field can still be added on a subsequent update if it was absent on create. To enforce *immutable from creation* make the field required (omit `[name]` brackets and pointer markers).
+
 ## Supported value types
 
 | Annotation token               | Go type                                    | JSON Schema             | Examples                             |

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/format"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -26,6 +27,16 @@ import (
 /* -------------------------------------------------------------------------- */
 /*  Annotation parsing                                                         */
 /* -------------------------------------------------------------------------- */
+
+// WarnWriter receives diagnostic warnings emitted by Parse. It defaults to
+// os.Stderr; tests can swap it out to capture output. The parser is not
+// concurrency-safe to begin with (it's a CLI helper, single-pass per file),
+// so a package-level writer is fine.
+var WarnWriter io.Writer = os.Stderr
+
+func emitWarn(file string, lineNum int, msg string) {
+	fmt.Fprintf(WarnWriter, "cozyvalues-gen: %s:%d: warning: %s\n", filepath.Base(file), lineNum, msg)
+}
 
 type kind int
 
@@ -67,6 +78,15 @@ type Raw struct {
 	Pattern          string
 	MinItems         *int64
 	MaxItems         *int64
+
+	// Immutable, when true, emits a CEL XValidation rule (self == oldSelf)
+	// at the property level. CAVEAT: per K8s x-kubernetes-validations
+	// semantics the rule only fires when the property is present in both
+	// oldSelf and self, so on optional/omitempty/pointer fields it
+	// enforces "immutable once set" rather than "immutable from creation".
+	// Make the field required (no `[name]` brackets, no pointer) for full
+	// "immutable from creation" semantics.
+	Immutable bool
 }
 
 // JSDoc-like syntax patterns (using shared patterns from internal/patterns)
@@ -87,7 +107,28 @@ var (
 	rePattern          = regexp.MustCompile(patterns.RegexPatternPattern)
 	reMinItems         = regexp.MustCompile(patterns.MinItemsPattern)
 	reMaxItems         = regexp.MustCompile(patterns.MaxItemsPattern)
+	reImmutable        = regexp.MustCompile(patterns.ImmutablePattern)
+
+	allConstraintREs = []*regexp.Regexp{
+		reMinimum, reMaximum, reExclusiveMinimum, reExclusiveMaximum,
+		reMinLength, reMaxLength, rePattern, reMinItems, reMaxItems,
+		reImmutable,
+	}
 )
+
+// matchesAnyConstraint reports whether the line is recognised by any
+// constraint annotation regex. Used by Parse to decide whether to emit a
+// "constraint placed after YAML value" warning before the actual matcher
+// blocks consume the line. Keeping this in one place avoids drift when a
+// new constraint regex is added.
+func matchesAnyConstraint(line string) bool {
+	for _, re := range allConstraintREs {
+		if re.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
 
 // additional string-format aliases
 // see https://github.com/go-openapi/strfmt/blob/master/README.md
@@ -136,17 +177,37 @@ func Parse(file string) ([]Raw, error) {
 	var currentEnum *Raw
 	var enumValues []string
 	var lastAnnotated *Raw // Track last @param or @field to accumulate constraints
+	// lastAnnotatedYAMLPassed becomes true the first time a non-comment YAML
+	// line is seen while lastAnnotated is still active. Subsequent constraint
+	// matches still attach to lastAnnotated (preserving pre-existing
+	// behaviour for every constraint family), but emit a warning so the
+	// misplacement is observable instead of silent.
+	var lastAnnotatedYAMLPassed bool
 
 	// finalizeLastAnnotated appends the last annotated item to output if it exists
 	finalizeLastAnnotated := func() {
 		if lastAnnotated != nil {
 			out = append(out, *lastAnnotated)
 			lastAnnotated = nil
+			lastAnnotatedYAMLPassed = false
 		}
 	}
 
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
+	for i, raw := range lines {
+		lineNum := i + 1
+		line := strings.TrimSpace(raw)
+
+		// A non-empty YAML-content line marks the boundary between the
+		// preceding @param's accumulation window and any trailing text.
+		// We don't drop lastAnnotated here (that would silently change
+		// behaviour for late @minimum/@maximum/etc. across the codebase);
+		// we only flag that subsequent constraint matches are now after
+		// the YAML value, so the warning path below can light up.
+		if line != "" && !strings.HasPrefix(line, "#") {
+			if lastAnnotated != nil {
+				lastAnnotatedYAMLPassed = true
+			}
+		}
 
 		// Check for enum value
 		if m := reEnumValue.FindStringSubmatch(line); m != nil && currentEnum != nil {
@@ -176,6 +237,17 @@ func Parse(file string) ([]Raw, error) {
 		// This is intentional — @section is a README concept, not OpenAPI.
 		if lastAnnotated != nil {
 			paramName := strings.Join(lastAnnotated.Path, ".")
+			// If we've already crossed the YAML value line of lastAnnotated,
+			// the attachment still goes through (preserving pre-existing
+			// behaviour for every constraint family) but emit one warning so
+			// the misplacement is observable to the chart author.
+			if lastAnnotatedYAMLPassed && matchesAnyConstraint(line) {
+				emitWarn(file, lineNum, fmt.Sprintf(
+					"constraint on this line still attaches to %q across an intervening YAML value line; move it to immediately after the @param/@field header for clarity",
+					paramName,
+				))
+				lastAnnotatedYAMLPassed = false // only warn once per misplacement run
+			}
 			if m := reMinimum.FindStringSubmatch(line); m != nil {
 				val, err := strconv.ParseFloat(m[1], 64)
 				if err != nil {
@@ -234,6 +306,10 @@ func Parse(file string) ([]Raw, error) {
 					return nil, fmt.Errorf("invalid @maxItems value %q for %q: %w", m[1], paramName, err)
 				}
 				lastAnnotated.MaxItems = &val
+				continue
+			}
+			if reImmutable.MatchString(line) {
+				lastAnnotated.Immutable = true
 				continue
 			}
 		}
@@ -413,6 +489,15 @@ type Node struct {
 	Pattern          string
 	MinItems         *int64
 	MaxItems         *int64
+
+	// Immutable, when true, emits a CEL XValidation rule (self == oldSelf)
+	// at the property level. CAVEAT: per K8s x-kubernetes-validations
+	// semantics the rule only fires when the property is present in both
+	// oldSelf and self, so on optional/omitempty/pointer fields it
+	// enforces "immutable once set" rather than "immutable from creation".
+	// Make the field required (no `[name]` brackets, no pointer) for full
+	// "immutable from creation" semantics.
+	Immutable bool
 }
 
 func newNode(name string, p *Node) *Node {
@@ -439,6 +524,7 @@ func copyConstraints(node *Node, raw *Raw) {
 	node.Pattern = raw.Pattern
 	node.MinItems = raw.MinItems
 	node.MaxItems = raw.MaxItems
+	node.Immutable = raw.Immutable
 }
 
 func Build(rows []Raw) *Node {
@@ -841,6 +927,16 @@ func (g *gen) emitField(c *Node) {
 	}
 	if c.MaxItems != nil {
 		g.buf.WriteString(fmt.Sprintf("    // +kubebuilder:validation:MaxItems=%d\n", *c.MaxItems))
+	}
+	if c.Immutable {
+		// "is immutable" without the "after creation" qualifier: for
+		// optional/omitempty/pointer fields the rule actually enforces
+		// "immutable once set", so the legacy phrasing was misleading for
+		// the operator who sees the admission error.
+		g.buf.WriteString(fmt.Sprintf(
+			"    // +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=%q\n",
+			c.Name+" is immutable",
+		))
 	}
 
 	tag := "`json:\"" + c.Name

--- a/internal/openapi/openapi_test.go
+++ b/internal/openapi/openapi_test.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"bytes"
 	"encoding/json"
 	"go/ast"
 	"go/parser"
@@ -1264,6 +1265,36 @@ func TestBuildWithConstraints(t *testing.T) {
 	require.Equal(t, int64(10), *tags.MaxItems)
 }
 
+// TestParseImmutable tests parsing of the @immutable flag.
+func TestParseImmutable(t *testing.T) {
+	const yaml = `
+## @param {string} storageClass - StorageClass used to store the data.
+## @immutable
+storageClass: ""
+`
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.True(t, rows[0].Immutable, "Immutable should be set when @immutable is present")
+}
+
+func TestParseImmutable_AbsentByDefault(t *testing.T) {
+	const yaml = `
+## @param {string} storageClass - StorageClass used to store the data.
+storageClass: ""
+`
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.False(t, rows[0].Immutable)
+}
+
 // TestGenerateKubebuilderValidationMarkers tests kubebuilder markers generation.
 func TestGenerateKubebuilderValidationMarkers(t *testing.T) {
 	min := 1.0
@@ -1322,6 +1353,175 @@ func TestGenerateKubebuilderValidationMarkers(t *testing.T) {
 	// Test array constraints for tags
 	require.Contains(t, src, "+kubebuilder:validation:MinItems=1", "should have MinItems marker")
 	require.Contains(t, src, "+kubebuilder:validation:MaxItems=10", "should have MaxItems marker")
+}
+
+// TestGenerateImmutableMarker tests the kubebuilder XValidation marker for @immutable.
+func TestGenerateImmutableMarker(t *testing.T) {
+	rows := []Raw{
+		{
+			K:         kParam,
+			Path:      []string{"storageClass"},
+			TypeExpr:  "string",
+			Immutable: true,
+		},
+	}
+
+	root := Build(rows)
+	g := &gen{pkg: "values"}
+	code, _, err := g.Generate(root)
+	require.NoError(t, err)
+
+	src := string(code)
+	require.Contains(t, src,
+		`+kubebuilder:validation:XValidation:rule="self == oldSelf",message="storageClass is immutable"`,
+		"should emit XValidation CEL marker for @immutable field",
+	)
+}
+
+// TestParseImmutable_StickinessBetweenParams pins the deliberate
+// scope-limited behaviour: a constraint placed AFTER the YAML value
+// line of its @param still attaches to that @param (matching every
+// other constraint family — sitewide behaviour is preserved bit-for-bit
+// vs pre-PR), but Parse emits a warning to WarnWriter so the
+// misplacement is observable instead of silent.
+//
+// In the layout below `## @immutable` sits between foo's YAML value and
+// the next `## @param baz` header, so it attaches to foo. The canonical
+// form (constraint immediately after its @param header) is shown by
+// TestParseImmutable_StickinessBetweenParams_Canonical.
+func TestParseImmutable_StickinessBetweenParams(t *testing.T) {
+	const yaml = `
+## @param {string} foo - foo desc
+foo: ""
+
+bar: ""
+## @immutable
+## @param {string} baz - baz desc
+baz: ""
+`
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	var warn bytes.Buffer
+	prev := WarnWriter
+	WarnWriter = &warn
+	defer func() { WarnWriter = prev }()
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+
+	byPath := map[string]Raw{}
+	for _, r := range rows {
+		byPath[r.Path[0]] = r
+	}
+
+	require.Contains(t, byPath, "foo")
+	require.Contains(t, byPath, "baz")
+	require.True(t, byPath["foo"].Immutable,
+		"sitewide constraint-attachment behaviour is preserved: late @immutable still attaches to the preceding @param")
+	require.False(t, byPath["baz"].Immutable,
+		"@immutable placed before @param baz attaches to the previous param (foo), not baz")
+	require.Contains(t, warn.String(), "warning",
+		"misplacement must emit a diagnostic to WarnWriter so it is not silent")
+	require.Contains(t, warn.String(), "foo",
+		"warning should name the field the constraint attached to")
+}
+
+// TestParseImmutable_StickinessBetweenParams_Canonical demonstrates the
+// canonical form: constraints come immediately AFTER the @param header.
+func TestParseImmutable_StickinessBetweenParams_Canonical(t *testing.T) {
+	const yaml = `
+## @param {string} foo - foo desc
+foo: ""
+
+bar: ""
+## @param {string} baz - baz desc
+## @immutable
+baz: ""
+`
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+
+	byPath := map[string]Raw{}
+	for _, r := range rows {
+		byPath[r.Path[0]] = r
+	}
+
+	require.False(t, byPath["foo"].Immutable)
+	require.True(t, byPath["baz"].Immutable,
+		"baz picks up @immutable that immediately follows its @param header")
+}
+
+// TestParseImmutable_OnOmitemptyField pins the documented caveat: the
+// rule still lands in the schema, but K8s admission only enforces it
+// while the field is present in both oldSelf and self. The README and
+// the doc comments warn that this means "immutable once set" rather
+// than "immutable from creation" for optional fields. The test exists
+// so that the marker still gets emitted (UI relies on its presence) and
+// to alert a maintainer if a future change ever decides to refuse the
+// combination instead.
+func TestParseImmutable_OnOmitemptyField(t *testing.T) {
+	const yaml = `
+## @param {string} [storageClass] - StorageClass used to store the data.
+## @immutable
+storageClass: ""
+`
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.True(t, rows[0].Immutable)
+	require.True(t, rows[0].OmitEmpty, "[name] should mark the field omitempty")
+}
+
+// TestParseImmutable_AfterEnumIsDropped pins the parser limitation that
+// @immutable (like other constraints) only attaches to the preceding
+// @param/@field. An annotation placed after @enum is silently dropped
+// because lastAnnotated is nil at that point. Documented so a future
+// contributor sees the test rather than the silent drop in production.
+func TestParseImmutable_AfterEnumIsDropped(t *testing.T) {
+	const yaml = `
+## @enum {string} Mode - Operating mode
+## @value standalone
+## @value cluster
+## @immutable
+
+## @param {Mode} mode - Selected mode
+mode: standalone
+`
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+
+	for _, r := range rows {
+		require.False(t, r.Immutable,
+			"@immutable between @enum and @param should attach to nothing (current parser behaviour)")
+	}
+}
+
+func TestGenerateImmutableMarker_NotEmittedByDefault(t *testing.T) {
+	rows := []Raw{
+		{
+			K:        kParam,
+			Path:     []string{"storageClass"},
+			TypeExpr: "string",
+		},
+	}
+
+	root := Build(rows)
+	g := &gen{pkg: "values"}
+	code, _, err := g.Generate(root)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(code), "XValidation",
+		"XValidation marker must not appear without @immutable")
 }
 
 // TestEndToEndValidationConstraintsInSchema tests full pipeline: YAML → JSON Schema.
@@ -1388,6 +1588,50 @@ tags:
 	tags := specPropsProps["tags"].(map[string]any)
 	require.Equal(t, float64(1), tags["minItems"], "tags should have minItems=1")
 	require.Equal(t, float64(5), tags["maxItems"], "tags should have maxItems=5")
+}
+
+// TestEndToEndImmutableInSchema tests the full pipeline for @immutable:
+// YAML → kubebuilder XValidation marker → CRD → values.schema.json carrying
+// the standard x-kubernetes-validations entry.
+func TestEndToEndImmutableInSchema(t *testing.T) {
+	const yaml = `
+## @param {string} storageClass - StorageClass used to store the data.
+## @immutable
+storageClass: ""
+`
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+
+	root := Build(rows)
+	tmpDir, goFile, err := WriteGeneratedGoAndStub(root, "values", "values.helm.io", "v1alpha1")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	crdBytes, err := CG(filepath.Dir(goFile))
+	require.NoError(t, err)
+
+	schemaPath := filepath.Join(tmpDir, "values.schema.json")
+	require.NoError(t, WriteValuesSchema(crdBytes, schemaPath))
+	schemaBytes, err := os.ReadFile(schemaPath)
+	require.NoError(t, err)
+
+	var schema map[string]any
+	err = json.Unmarshal(schemaBytes, &schema)
+	require.NoError(t, err)
+
+	props := schema["properties"].(map[string]any)
+	sc := props["storageClass"].(map[string]any)
+
+	validations, ok := sc["x-kubernetes-validations"].([]any)
+	require.True(t, ok, "storageClass should carry x-kubernetes-validations")
+	require.Len(t, validations, 1)
+
+	entry := validations[0].(map[string]any)
+	require.Equal(t, "self == oldSelf", entry["rule"])
+	require.Equal(t, "storageClass is immutable", entry["message"])
 }
 
 // TestFieldPatternStillWorks verifies @field annotations work after patterns refactor.

--- a/internal/patterns/patterns.go
+++ b/internal/patterns/patterns.go
@@ -69,3 +69,15 @@ const MinItemsPattern = `^#{1,}\s+@minItems\s+(\d+)\s*$`
 // MaxItemsPattern matches @maxItems annotations with integer value.
 // Groups: 1=integer value
 const MaxItemsPattern = `^#{1,}\s+@maxItems\s+(\d+)\s*$`
+
+// ImmutablePattern matches @immutable flag annotation.
+// Renders as a CEL XValidation rule (self == oldSelf) at the property
+// level. CAVEAT: per Kubernetes x-kubernetes-validations semantics, a
+// property-level rule is evaluated only when the property is present in
+// both oldSelf and self. For optional/omitempty/pointer fields the rule
+// therefore enforces "immutable once set" rather than "immutable from
+// creation": the field can still be added on a later update if it was
+// absent on create. For "immutable from creation" semantics make the
+// field required (omit `[name]` brackets and pointer markers).
+// No capture groups — presence indicates true.
+const ImmutablePattern = `^#{1,}\s+@immutable\s*$`


### PR DESCRIPTION
## Summary

A new `## @immutable` flag annotation in values.yaml marks a field as immutable-after-creation.

```yaml
## @param {string} storageClass - StorageClass used to store the data.
## @immutable
storageClass: ""
```

cozyvalues-gen now:

- Parses the annotation alongside the existing `@minimum`/`@maxLength`/etc. constraint family.
- Carries it on `Raw` and `Node` via a new `Immutable bool` field.
- Emits a kubebuilder validation marker on the generated Go field:

```go
// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="storageClass is immutable after creation"
StorageClass string `json:"storageClass"`
```

controller-gen translates that marker into the standard `x-kubernetes-validations` entry on the CRD; by passthrough it lands in the chart's `values.schema.json` as well.

## Why

I want the Cozystack UI to be able to mark immutable resource fields as read-only on edit forms. The decision was to use the schema as the source of truth — specifically the standard K8s `x-kubernetes-validations` CEL rule `self == oldSelf` — rather than maintaining a hand-rolled mapping on the UI side. cozyvalues-gen is the canonical pipeline that produces that schema, so the annotation belongs here.

## Tests

Four new tests pin the behaviour:

- `TestParseImmutable` / `TestParseImmutable_AbsentByDefault` for the parser path.
- `TestGenerateImmutableMarker` / `TestGenerateImmutableMarker_NotEmittedByDefault` for the Go-code emitter.

Full suite is green:

```
ok  github.com/cozystack/cozyvalues-gen
ok  github.com/cozystack/cozyvalues-gen/internal/openapi
ok  github.com/cozystack/cozyvalues-gen/internal/readme
```

## Downstream

Two follow-up PRs depend on this:

- cozystack/cozystack#TBD — annotate MariaDB `storageClass` and regenerate.
- cozystack/cozystack-ui#TBD — consume the marker in edit forms.