### PR TITLE
feat: add intOrString type alias for map[string]intOrString annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ size: "medium"
 | `time`                         | `metav1.Time`                              | string (RFC 3339)       | `"2025-08-07T12:00:00Z"`             |
 | `object`                       | `k8sRuntime.RawExtension`                  | any JSON/YAML           | `{"aaa": 123, "foo": "bar"}`         |
 | `emptyobject`                  | empty struct (`struct{}`) **–** no fields  | `{}`                    | `{}`                                 |
+| `intOrString`                  | `intstr.IntOrString`                       | `anyOf` int or string   | `100`, `"100"` (PostgreSQL params)   |
 | `*<primitive>`                 | pointer to that primitive (`nil` allowed)  | primitive or `null`     | `"asd"`, `null` …                    |
 | `<CustomType>`                 | generated struct                           | object                  | declared from `@field` annotations   |
 | `*<CustomType>`                | pointer to generated struct                | object or `null`        | `null`                               |

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -45,6 +45,7 @@ const (
 	aliasResources   = "resources"
 	aliasRequest     = "request"
 	aliasLimit       = "limit"
+	aliasIntOrString = "intOrString"
 )
 
 type Raw struct {
@@ -575,7 +576,7 @@ func isPrimitive(t string) bool {
 	switch t {
 	case "string", "bool", "int", "int32", "int64", "float32", "float64",
 		aliasQuantity, aliasDuration, aliasTime,
-		aliasObject, aliasResources, aliasRequest, aliasLimit:
+		aliasObject, aliasResources, aliasRequest, aliasLimit, aliasIntOrString:
 		return true
 	default:
 		return false
@@ -632,6 +633,9 @@ func (g *gen) resolve(raw string) string {
 	case aliasObject:
 		g.addImpAlias("k8s.io/apimachinery/pkg/runtime", "k8sRuntime")
 		return "k8sRuntime.RawExtension"
+	case aliasIntOrString:
+		g.addImpAlias("k8s.io/apimachinery/pkg/util/intstr", "intstr")
+		return "intstr.IntOrString"
 	}
 
 	// context-aware resolution for well-known object-ish aliases

--- a/internal/openapi/openapi_test.go
+++ b/internal/openapi/openapi_test.go
@@ -429,9 +429,36 @@ postgresql:
 	require.NoError(t, err)
 	schemaBytes, err := os.ReadFile(outfile)
 	require.NoError(t, err)
-	schema := string(schemaBytes)
-	require.Contains(t, schema, `"x-kubernetes-int-or-string": true`)
-	require.Contains(t, schema, `"anyOf"`)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(schemaBytes, &doc))
+
+	props, ok := doc["properties"].(map[string]any)
+	require.True(t, ok, "schema has no top-level properties")
+	postgresql, ok := props["postgresql"].(map[string]any)
+	require.True(t, ok, "missing postgresql property")
+	postgresqlProps, ok := postgresql["properties"].(map[string]any)
+	require.True(t, ok, "postgresql has no properties")
+	parameters, ok := postgresqlProps["parameters"].(map[string]any)
+	require.True(t, ok, "missing postgresql.parameters property")
+	addProps, ok := parameters["additionalProperties"].(map[string]any)
+	require.True(t, ok, "parameters has no additionalProperties")
+
+	require.Equal(t, true, addProps["x-kubernetes-int-or-string"],
+		"additionalProperties.x-kubernetes-int-or-string must be true")
+
+	anyOf, ok := addProps["anyOf"].([]any)
+	require.True(t, ok, "additionalProperties.anyOf is missing or not an array")
+
+	types := make([]string, 0, len(anyOf))
+	for _, entry := range anyOf {
+		e, ok := entry.(map[string]any)
+		require.True(t, ok, "anyOf entry is not an object")
+		typeName, _ := e["type"].(string)
+		types = append(types, typeName)
+	}
+	require.ElementsMatch(t, []string{"integer", "string"}, types,
+		"anyOf must contain exactly {type:integer} and {type:string}")
 }
 
 /* -------------------------------------------------------------------------- */

--- a/internal/openapi/openapi_test.go
+++ b/internal/openapi/openapi_test.go
@@ -393,6 +393,45 @@ func TestResolveSpecialAliases(t *testing.T) {
 	// ensure imports were recorded
 	require.Contains(t, g.imp, "k8s.io/apimachinery/pkg/apis/meta/v1")
 	require.Contains(t, g.imp, "k8s.io/apimachinery/pkg/api/resource")
+
+	require.Equal(t, "intstr.IntOrString", g.resolve("intOrString"))
+	require.Contains(t, g.imp, "k8s.io/apimachinery/pkg/util/intstr")
+}
+
+func TestIntOrStringSchemaGeneration(t *testing.T) {
+	src := `## @typedef {struct} PostgreSQL
+## @field {map[string]intOrString} [parameters] - PostgreSQL parameters, strings or integers.
+
+## @param {PostgreSQL} postgresql - PostgreSQL server configuration.
+postgresql:
+  parameters:
+    max_connections: "100"
+`
+	tmpfile := writeTempFile(src)
+	rows, err := Parse(tmpfile)
+	require.NoError(t, err)
+	root := Build(rows)
+
+	g := &gen{pkg: "testpkg", groupName: "apps.cozystack.io", versionName: "v1alpha1"}
+	goCode, _, err := g.Generate(root)
+	require.NoError(t, err)
+	require.Contains(t, string(goCode), "intstr.IntOrString")
+	require.Contains(t, string(goCode), `"k8s.io/apimachinery/pkg/util/intstr"`)
+
+	// Verify full schema generation produces anyOf for intOrString map values.
+	tmpdir, gofile, err := WriteGeneratedGoAndStub(root, "testpkg", "apps.cozystack.io", "v1alpha1")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+	crdBytes, err := CG(filepath.Dir(gofile))
+	require.NoError(t, err)
+	outfile := filepath.Join(tmpdir, "schema.json")
+	err = WriteValuesSchema(crdBytes, outfile)
+	require.NoError(t, err)
+	schemaBytes, err := os.ReadFile(outfile)
+	require.NoError(t, err)
+	schema := string(schemaBytes)
+	require.Contains(t, schema, `"x-kubernetes-int-or-string": true`)
+	require.Contains(t, schema, `"anyOf"`)
 }
 
 /* -------------------------------------------------------------------------- */

--- a/internal/readme/readme.go
+++ b/internal/readme/readme.go
@@ -1107,7 +1107,7 @@ func defaultValueForType(t string) string {
 		return "`[]`"
 	case strings.HasPrefix(base, "map["):
 		return "`{}`"
-	case base == "string", base == aliasQuantity:
+	case base == "string", base == aliasQuantity, base == aliasIntOrString:
 		return "`\"\"`"
 	case base == "int":
 		return "`0`"

--- a/internal/readme/readme.go
+++ b/internal/readme/readme.go
@@ -19,6 +19,7 @@ const (
 	aliasTime        = "time"
 	aliasObject      = "object"
 	aliasEmptyObject = "emptyobject"
+	aliasIntOrString = "intOrString"
 )
 
 // additional string-format aliases
@@ -869,7 +870,7 @@ func isPrimitive(t string) bool {
 	switch base {
 	case "string", "bool", "int", "int32", "int64",
 		"float32", "float64",
-		aliasQuantity, aliasDuration, aliasTime, aliasObject, aliasEmptyObject:
+		aliasQuantity, aliasDuration, aliasTime, aliasObject, aliasEmptyObject, aliasIntOrString:
 		return true
 	default:
 		return false

--- a/internal/readme/readme_test.go
+++ b/internal/readme/readme_test.go
@@ -946,6 +946,24 @@ topology:
 	require.NotContains(t, table, "`*object`", "pointer-to-enum should not be *object")
 }
 
+func TestDefaultValueForTypeIntOrString(t *testing.T) {
+	require.Equal(t, "`\"\"`", defaultValueForType("intOrString"),
+		"scalar intOrString without a value should render as empty string, not {}")
+}
+
+func TestIntOrStringScalarRendersAsEmptyString(t *testing.T) {
+	yamlContent := `
+## @param {intOrString} threshold - Scalar that may be string or integer
+threshold:
+`
+	table := renderTableFromValues(t, yamlContent)
+	require.Contains(t, table, "`threshold`")
+	require.Contains(t, table, "`\"\"`",
+		"scalar intOrString without a value should render as empty string in the README table")
+	require.NotContains(t, table, "`{}`",
+		"scalar intOrString must not fall through to object default")
+}
+
 func TestArrayOfEnumsDisplaysCorrectly(t *testing.T) {
 	yamlContent := `
 ## @enum {string} PresetSize - Size preset


### PR DESCRIPTION
## Summary

- Add `intOrString` as a new primitive type alias in both `openapi` and `readme` packages
- Resolves to `intstr.IntOrString` (`k8s.io/apimachinery/pkg/util/intstr`) in generated Go code
- Produces `anyOf: [{type: integer}, {type: string}]` + `x-kubernetes-int-or-string: true` in JSON Schema

## Motivation

Some Helm chart parameters (e.g. PostgreSQL server parameters like `max_connections`) are naturally expressed as integers, but users sometimes supply them without quoting. The current `{map[string]string}` annotation rejects integer values at schema validation time, causing `HelmRelease` failures for existing clusters that have unquoted integers in their Application spec.

With `{map[string]intOrString}`, the schema accepts both `max_connections: "100"` (string) and `max_connections: 100` (integer), while the Helm template already handles coercion via `{{ $value | toString | quote }}`.

## Test plan

- [x] Unit test `TestResolveSpecialAliases` extended to verify `intOrString` → `intstr.IntOrString` resolution and import
- [x] New integration test `TestIntOrStringSchemaGeneration` verifies end-to-end schema generation produces `x-kubernetes-int-or-string: true` and `anyOf`
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognizes Kubernetes intOrString as a primitive for generation; generated code references the appropriate Go type and import.
  * Generated schemas mark intOrString maps with the x-kubernetes-int-or-string marker and represent map values as integer|string alternatives.

* **Documentation**
  * README updated to list intOrString in supported value types and describe its mapping.

* **Tests**
  * Added and expanded tests to validate intOrString handling, code references, README rendering, and schema output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozyvalues-gen/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->