### PR TITLE
feat: add date-time string format and @example annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,35 @@ These tokens map to a plain `string` field, **plus** `format: "<alias>"` in the 
 | `byte`          | `SGVsbG8=` (base64)                    |
 | `password`      | *(hidden by most UIs)*                 |
 | `date`          | `2025-08-07`                           |
+| `date-time`     | `2025-08-07T12:34:56Z`                 |
 
 > **Tip:** use any alias exactly like a regular type, e.g.  
 > ```yaml
 > ## @param apiURL {uri} External URL of the API
 > apiURL: ""
 > ```
+
+### @example
+
+Attach OpenAPI `examples` to the most-recent `@param` / `@field` / `@property`.
+Each `@example` line accepts one JSON-encoded value (double-quoted string,
+number, boolean, `null`, object, array). Single-quoted strings and bare tokens
+are coerced to JSON strings. Multiple lines accumulate into an `examples` array.
+
+```yaml
+## @param {date-time} restoreAt - Point-in-time recovery target.
+## @example "2026-05-28T12:34:56Z"
+restoreAt: ""
+
+## @typedef {struct} Sizing
+## @field {string} flavor - Instance flavor.
+## @example "small"
+## @example "large"
+```
+
+The values land in the generated `values.schema.json` as
+`"examples": ["2026-05-28T12:34:56Z"]` on the matching property, which JSON
+Schema renderers (RJSF, etc.) pick up as placeholder/example text.
 
 ---
 

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -93,6 +93,10 @@ type Raw struct {
 	// (keys starting with "x-") attached via @x-<keyword> directives.
 	// These are emitted verbatim into the JSON schema only, never into Go types.
 	Extensions map[string]interface{}
+
+	// Examples are JSON-encoded values accumulated from `## @example <value>` lines.
+	// They are surfaced as the OpenAPI `examples` array on the matching schema property.
+	Examples []json.RawMessage
 }
 
 // JSDoc-like syntax patterns (using shared patterns from internal/patterns)
@@ -114,6 +118,7 @@ var (
 	reMinItems         = regexp.MustCompile(patterns.MinItemsPattern)
 	reMaxItems         = regexp.MustCompile(patterns.MaxItemsPattern)
 	reImmutable        = regexp.MustCompile(patterns.ImmutablePattern)
+	reExample          = regexp.MustCompile(patterns.ExamplePattern)
 
 	// Vendor extension directive (@x-<keyword>)
 	reVendorExtension = regexp.MustCompile(patterns.VendorExtensionPattern)
@@ -164,6 +169,7 @@ var stringFormats = []string{
 	"byte",
 	"password",
 	"date",
+	"date-time",
 }
 
 func isStringFormat(s string) bool {
@@ -173,6 +179,27 @@ func isStringFormat(s string) bool {
 		}
 	}
 	return false
+}
+
+// normalizeExample converts a captured @example value into a json.RawMessage.
+// Accepts JSON literals (`"x"`, numbers, booleans, null, objects, arrays),
+// single-quoted strings, and bare tokens — the latter two are coerced to JSON strings.
+func normalizeExample(raw string) (json.RawMessage, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("empty example")
+	}
+	// Single-quoted → JSON-quoted.
+	if len(raw) >= 2 && raw[0] == '\'' && raw[len(raw)-1] == '\'' {
+		return json.Marshal(raw[1 : len(raw)-1])
+	}
+	// Already-valid JSON.
+	var probe interface{}
+	if err := json.Unmarshal([]byte(raw), &probe); err == nil {
+		return json.RawMessage(raw), nil
+	}
+	// Bare token (e.g. `foo`, `2026-05-28T12:34:56Z` without quotes) → JSON string.
+	return json.Marshal(raw)
 }
 
 func Parse(file string) ([]Raw, error) {
@@ -331,6 +358,14 @@ func Parse(file string) ([]Raw, error) {
 					lastAnnotated.Extensions = map[string]interface{}{}
 				}
 				lastAnnotated.Extensions[key] = value
+				continue
+			}
+			if m := reExample.FindStringSubmatch(line); m != nil {
+				ex, err := normalizeExample(m[1])
+				if err != nil {
+					return nil, fmt.Errorf("invalid @example value %q for %q: %w", m[1], paramName, err)
+				}
+				lastAnnotated.Examples = append(lastAnnotated.Examples, ex)
 				continue
 			}
 		}
@@ -523,6 +558,9 @@ type Node struct {
 	// Extensions holds arbitrary OpenAPI/JSON-Schema vendor extensions
 	// (keys starting with "x-"). Emitted into the JSON schema only.
 	Extensions map[string]interface{}
+
+	// Examples accumulated from `## @example` lines.
+	Examples []json.RawMessage
 }
 
 func newNode(name string, p *Node) *Node {
@@ -551,6 +589,9 @@ func copyConstraints(node *Node, raw *Raw) {
 	node.MaxItems = raw.MaxItems
 	node.Immutable = raw.Immutable
 	node.Extensions = raw.Extensions
+	if len(raw.Examples) > 0 {
+		node.Examples = append(node.Examples[:0:0], raw.Examples...)
+	}
 }
 
 func Build(rows []Raw) *Node {
@@ -1289,22 +1330,23 @@ func structuralChildren(n *Node, aliases map[string]*Node) map[string]*Node {
 	return nil
 }
 
-// nodeSubtreeHasExtensions reports whether n or any node reachable from it
+// nodeSubtreeNeedsInjection reports whether n or any node reachable from it
 // (through inline children or typedef aliases for direct / []Type /
-// map[string]Type references) carries a vendor extension. Used to decide
-// whether a property needs the order-preserving injection path at all; when
-// it does not, the property is emitted via plain json.MarshalIndent so output
-// stays byte-identical to the pre-extension generator.
-func nodeSubtreeHasExtensions(n *Node, aliases map[string]*Node, seen map[*Node]bool) bool {
+// map[string]Type references) carries a vendor extension or an @example value.
+// Used to decide whether a property needs the order-preserving injection path
+// at all; when it does not, the property is emitted via plain
+// json.MarshalIndent so output stays byte-identical to the pre-extension
+// generator.
+func nodeSubtreeNeedsInjection(n *Node, aliases map[string]*Node, seen map[*Node]bool) bool {
 	if n == nil || seen[n] {
 		return false
 	}
 	seen[n] = true
-	if len(n.Extensions) > 0 {
+	if len(n.Extensions) > 0 || len(n.Examples) > 0 {
 		return true
 	}
 	for _, child := range structuralChildren(n, aliases) {
-		if nodeSubtreeHasExtensions(child, aliases, seen) {
+		if nodeSubtreeNeedsInjection(child, aliases, seen) {
 			return true
 		}
 	}
@@ -1312,17 +1354,30 @@ func nodeSubtreeHasExtensions(n *Node, aliases map[string]*Node, seen map[*Node]
 }
 
 // injectExtensions walks an order-preserving JSON schema node alongside its
-// corresponding Node, writing any vendor extensions (x-* keys) declared on
-// the node and recursively descending into nested object properties, array
-// items and map values. Extensions are emitted into the JSON schema only.
+// corresponding Node, writing any vendor extensions (x-* keys) and `examples`
+// arrays declared on the node and recursively descending into nested object
+// properties, array items and map values. Both are emitted into the JSON
+// schema only (`examples` is not a kubebuilder marker controller-gen emits, so
+// it is layered on here rather than coming from the generated CRD).
 //
-// Injected x-* keys are appended as the last key(s) of their object so that
-// all pre-existing keys keep their original relative order and position. This
+// Injected keys are appended as the last key(s) of their object so that all
+// pre-existing keys keep their original relative order and position. This
 // guarantees byte-identical output to the pre-extension generator for any
-// schema that carries no extensions.
+// schema that carries no extensions and no examples.
 func injectExtensions(schema *orderedMap, n *Node, aliases map[string]*Node) {
 	if schema == nil || n == nil {
 		return
+	}
+
+	if len(n.Examples) > 0 {
+		vals := make([]interface{}, 0, len(n.Examples))
+		for _, raw := range n.Examples {
+			var v interface{}
+			if err := json.Unmarshal(raw, &v); err == nil {
+				vals = append(vals, v)
+			}
+		}
+		schema.set("examples", vals)
 	}
 
 	for _, k := range sortedExtensionKeys(n.Extensions) {
@@ -1558,13 +1613,13 @@ func WriteValuesSchemaWithOrder(crdBytes []byte, outPath string, root *Node) err
 					first = false
 
 					// Fast path: when this property's subtree carries no
-					// vendor extensions, emit it via plain MarshalIndent so
-					// the output is byte-identical to the pre-extension
-					// generator (JSONSchemaProps marshals in struct-field
-					// order, not alphabetical). Only properties that actually
-					// carry an x-* directive take the order-preserving
-					// injection path below.
-					if !nodeSubtreeHasExtensions(node, root.Child, map[*Node]bool{}) {
+					// vendor extensions and no @example values, emit it via
+					// plain MarshalIndent so the output is byte-identical to
+					// the pre-extension generator (JSONSchemaProps marshals in
+					// struct-field order, not alphabetical). Only properties
+					// that actually carry an x-* directive or an @example take
+					// the order-preserving injection path below.
+					if !nodeSubtreeNeedsInjection(node, root.Child, map[*Node]bool{}) {
 						propJSON, err := json.MarshalIndent(prop, "    ", "  ")
 						if err != nil {
 							return err
@@ -1576,8 +1631,9 @@ func WriteValuesSchemaWithOrder(crdBytes []byte, outPath string, root *Node) err
 					// Injection path: marshal in struct-field order, round-trip
 					// through an order-preserving orderedMap (not a Go map,
 					// which sorts keys alphabetically), then append the x-*
-					// keys declared on this node and nested typedef fields
-					// without reordering any existing key.
+					// extension keys and `examples` arrays declared on this
+					// node and nested typedef fields without reordering any
+					// existing key.
 					rawJSON, err := json.Marshal(prop)
 					if err != nil {
 						return err

--- a/internal/openapi/openapi_test.go
+++ b/internal/openapi/openapi_test.go
@@ -1757,3 +1757,202 @@ func TestFieldConstraintsInBuild(t *testing.T) {
 	require.NotNil(t, portNode.Maximum)
 	require.Equal(t, 65535.0, *portNode.Maximum)
 }
+
+/* -------------------------------------------------------------------------- */
+/*  date-time format alias                                                    */
+/* -------------------------------------------------------------------------- */
+
+func TestDateTimeFormatAlias(t *testing.T) {
+	require.True(t, isStringFormat("date-time"), "date-time must be a registered string format")
+}
+
+func TestEmitFieldAddsDateTimeFormatAnnotation(t *testing.T) {
+	const valuesYAML = `
+## @param {date-time} restoreAt - RFC3339 timestamp
+restoreAt: ""
+`
+	rows, err := Parse(writeTempFile(valuesYAML))
+	require.NoError(t, err)
+	root := Build(rows)
+
+	g := &gen{pkg: "values"}
+	formatted, _, err := g.Generate(root)
+	require.NoError(t, err)
+
+	require.Contains(t, string(formatted), "// +kubebuilder:validation:Format=date-time",
+		"validation format annotation for date-time not found")
+}
+
+func TestSchemaContainsDateTimeFormat(t *testing.T) {
+	const yamlContent = `
+## @param {date-time} restoreAt - RFC3339 timestamp
+restoreAt: ""
+`
+	tmpValues := writeTempFile(yamlContent)
+	rows, err := Parse(tmpValues)
+	require.NoError(t, err)
+	root := Build(rows)
+
+	tmpDir, goFile, err := WriteGeneratedGoAndStub(root, "values", "values.helm.io", "v1alpha1")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	crdBytes, err := CG(filepath.Dir(goFile))
+	require.NoError(t, err)
+
+	outSchema := filepath.Join(tmpDir, "values.schema.json")
+	require.NoError(t, WriteValuesSchemaWithOrder(crdBytes, outSchema, root))
+
+	raw, err := os.ReadFile(outSchema)
+	require.NoError(t, err)
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(raw, &schema))
+
+	props := schema["properties"].(map[string]any)
+	restoreAt := props["restoreAt"].(map[string]any)
+	require.Equal(t, "string", restoreAt["type"])
+	require.Equal(t, "date-time", restoreAt["format"])
+}
+
+/* -------------------------------------------------------------------------- */
+/*  @example annotation                                                       */
+/* -------------------------------------------------------------------------- */
+
+func TestParseExampleOnParam(t *testing.T) {
+	const src = `
+## @param {string} apiURL - External URL
+## @example "https://api.example.com"
+apiURL: ""
+`
+	rows, err := Parse(writeTempFile(src))
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, []string{"apiURL"}, rows[0].Path)
+	require.Len(t, rows[0].Examples, 1)
+	require.JSONEq(t, `"https://api.example.com"`, string(rows[0].Examples[0]))
+}
+
+func TestParseExampleMultiple(t *testing.T) {
+	const src = `
+## @param {string} flavor - one of
+## @example "small"
+## @example "large"
+flavor: ""
+`
+	rows, err := Parse(writeTempFile(src))
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Len(t, rows[0].Examples, 2)
+	require.JSONEq(t, `"small"`, string(rows[0].Examples[0]))
+	require.JSONEq(t, `"large"`, string(rows[0].Examples[1]))
+}
+
+func TestParseExampleNonStringValues(t *testing.T) {
+	const src = `
+## @param {int} timeout - seconds
+## @example 30
+## @example 60
+timeout: 30
+`
+	rows, err := Parse(writeTempFile(src))
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Len(t, rows[0].Examples, 2)
+	require.JSONEq(t, `30`, string(rows[0].Examples[0]))
+	require.JSONEq(t, `60`, string(rows[0].Examples[1]))
+}
+
+func TestSchemaContainsExamplesOnParam(t *testing.T) {
+	const src = `
+## @param {date-time} restoreAt - RFC3339 timestamp
+## @example "2026-05-28T12:34:56Z"
+restoreAt: ""
+`
+	rows, err := Parse(writeTempFile(src))
+	require.NoError(t, err)
+	root := Build(rows)
+
+	tmpDir, goFile, err := WriteGeneratedGoAndStub(root, "values", "values.helm.io", "v1alpha1")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	crdBytes, err := CG(filepath.Dir(goFile))
+	require.NoError(t, err)
+
+	outSchema := filepath.Join(tmpDir, "values.schema.json")
+	require.NoError(t, WriteValuesSchemaWithOrder(crdBytes, outSchema, root))
+
+	raw, err := os.ReadFile(outSchema)
+	require.NoError(t, err)
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(raw, &schema))
+
+	restoreAt := schema["properties"].(map[string]any)["restoreAt"].(map[string]any)
+	require.Equal(t, "date-time", restoreAt["format"])
+	examples, ok := restoreAt["examples"].([]any)
+	require.True(t, ok, "examples must be an array on restoreAt; got %T", restoreAt["examples"])
+	require.Equal(t, []any{"2026-05-28T12:34:56Z"}, examples)
+}
+
+func TestSchemaContainsExamplesOnTypedefField(t *testing.T) {
+	const src = `
+## @typedef {struct} Bootstrap
+## @field {date-time} [recoveryTime] - point-in-time recovery target
+## @example "2026-05-28T12:34:56Z"
+
+## @param {Bootstrap} bootstrap - bootstrap config
+bootstrap:
+  recoveryTime: ""
+`
+	rows, err := Parse(writeTempFile(src))
+	require.NoError(t, err)
+	root := Build(rows)
+
+	tmpDir, goFile, err := WriteGeneratedGoAndStub(root, "values", "values.helm.io", "v1alpha1")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	crdBytes, err := CG(filepath.Dir(goFile))
+	require.NoError(t, err)
+
+	outSchema := filepath.Join(tmpDir, "values.schema.json")
+	require.NoError(t, WriteValuesSchemaWithOrder(crdBytes, outSchema, root))
+
+	raw, err := os.ReadFile(outSchema)
+	require.NoError(t, err)
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(raw, &schema))
+
+	bootstrap := schema["properties"].(map[string]any)["bootstrap"].(map[string]any)
+	recoveryTime := bootstrap["properties"].(map[string]any)["recoveryTime"].(map[string]any)
+	require.Equal(t, "date-time", recoveryTime["format"])
+	require.Equal(t, []any{"2026-05-28T12:34:56Z"}, recoveryTime["examples"])
+}
+
+func TestSchemaOmitsExamplesWhenAbsent(t *testing.T) {
+	const src = `
+## @param {string} bare - no examples here
+bare: ""
+`
+	rows, err := Parse(writeTempFile(src))
+	require.NoError(t, err)
+	root := Build(rows)
+
+	tmpDir, goFile, err := WriteGeneratedGoAndStub(root, "values", "values.helm.io", "v1alpha1")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	crdBytes, err := CG(filepath.Dir(goFile))
+	require.NoError(t, err)
+
+	outSchema := filepath.Join(tmpDir, "values.schema.json")
+	require.NoError(t, WriteValuesSchemaWithOrder(crdBytes, outSchema, root))
+
+	raw, err := os.ReadFile(outSchema)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), `"examples"`,
+		"examples key must not appear when no @example annotations are present")
+}

--- a/internal/patterns/patterns.go
+++ b/internal/patterns/patterns.go
@@ -88,3 +88,8 @@ const ImmutablePattern = `^#{1,}\s+@immutable\s*$`
 // directives (@param/@field/@enum/@minimum/...) since none of those begin with "x-".
 // Groups: 1=full key (e.g. "x-cozystack-options"), 2=raw value text (parsed as YAML flow)
 const VendorExtensionPattern = `^#{1,}\s+@(x-[A-Za-z0-9][\w-]*)\s+(.+)$`
+
+// ExamplePattern matches @example annotations and captures the literal JSON value.
+// Multiple @example lines accumulate into the OpenAPI `examples` array on the preceding @param/@field.
+// Groups: 1=raw value (any token DefaultValuePattern accepts — quoted strings, numbers, JSON, etc.)
+const ExamplePattern = `^#{1,}\s+@example\s+(` + DefaultValuePattern + `)\s*$`


### PR DESCRIPTION
## Summary
- Adds `date-time` to the string-format alias list, mirroring the existing `date` alias.
- Adds a new `## @example <value>` annotation that accumulates JSON-encoded values into an `"examples": [...]` array on the matching schema property. Layered on during JSON marshaling because `examples` is not a kubebuilder marker controller-gen emits.
- README updated.

Motivation: needed downstream in cozystack to render a date-time picker for the postgres `bootstrap.recoveryTime` field via a schema-driven UI.

## Test plan
- [x] `go test ./...` — all existing tests pass, plus 9 new tests covering format-alias recognition, `@example` parsing (single, multiple, non-string), schema emission at param and typedef-field levels, and the no-example no-op case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a `date-time` string-format alias
  * `@example` annotation to attach one or more example values to params/fields; examples are emitted into generated JSON schemas

* **Documentation**
  * README updated with `date-time` alias and an `@example` usage section showing JSON-encoded rules and worked examples

* **Tests**
  * Added tests covering date-time aliasing, `@example` parsing, accumulation, non-string examples, and schema emission/omission of examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->