### PR TITLE
feat: add @x-<keyword> directive for vendor schema extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,38 @@ so the misplacement is visible in `make generate` output. The warning never fail
 
 `@immutable` is a flag (no argument). It emits a CEL `XValidation` rule (`self == oldSelf`) at the property level. **Caveat**: per Kubernetes `x-kubernetes-validations` semantics, a property-level rule is evaluated only when the property is present in both `oldSelf` and `self`. For optional/omitempty/pointer fields the rule therefore enforces *immutable once set* rather than *immutable from creation* — the field can still be added on a subsequent update if it was absent on create. To enforce *immutable from creation* make the field required (omit `[name]` brackets and pointer markers).
 
+### Vendor extensions (`@x-...`)
+
+Attach an arbitrary OpenAPI/JSON-Schema **vendor extension keyword** (any key starting with `x-`) to a `@param` or `@field`. The directive name carries the keyword: `## @x-<keyword> <value>` emits `x-<keyword>: <value>` onto that property in the generated JSON schema. The value is parsed as YAML flow, so objects, arrays and scalars are all supported. This is a pure passthrough — no keyword is interpreted or hardcoded.
+
+Vendor extensions are emitted into the **JSON schema only**; they never appear in the generated Go types (extensions are schema metadata, not data shapes).
+
+```yaml
+## @param {string} instanceType - Virtual Machine instance type.
+## @x-cozystack-options {source: instancetype}
+instanceType: "u1.medium"
+```
+
+produces:
+
+```json
+"instanceType": {
+  "type": "string",
+  "description": "Virtual Machine instance type.",
+  "x-cozystack-options": { "source": "instancetype" }
+}
+```
+
+When declared on a `@typedef` field, the extension propagates everywhere the type is referenced — including `[]Type` (under `items.properties`) and `map[string]Type` (under `additionalProperties.properties`):
+
+```yaml
+## @typedef {struct} GPU - GPU device configuration.
+## @field {string} name - The name of the GPU resource to attach.
+## @x-cozystack-options {source: gpu}
+```
+
+Multiple `@x-*` lines may be attached to a single field (each with a distinct key). Values may be objects (`{a: 1}`), arrays (`[{a: 1}]`) or scalars (`42`, `true`, `"text"`). Injected `x-*` keys are appended after the property's existing keys, so adding a vendor extension never reorders the rest of the schema.
+
 ## Supported value types
 
 | Annotation token               | Go type                                    | JSON Schema             | Examples                             |

--- a/internal/openapi/extensions_test.go
+++ b/internal/openapi/extensions_test.go
@@ -1,0 +1,345 @@
+package openapi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// schemaBytesFor generates the values.schema.json for the given annotated
+// values and returns the raw file contents (key order preserved).
+func schemaBytesFor(t *testing.T, yaml string) string {
+	t.Helper()
+
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+
+	root := Build(rows)
+	tmpDir, goFile, err := WriteGeneratedGoAndStub(root, "values", "values.helm.io", "v1alpha1")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	crdBytes, err := CG(filepath.Dir(goFile))
+	require.NoError(t, err)
+
+	schemaPath := filepath.Join(tmpDir, "values.schema.json")
+	require.NoError(t, WriteValuesSchemaWithOrder(crdBytes, schemaPath, root))
+
+	schemaBytes, err := os.ReadFile(schemaPath)
+	require.NoError(t, err)
+	return string(schemaBytes)
+}
+
+// schemaProps generates the values.schema.json for the given annotated values
+// and returns the decoded top-level "properties" map for inspection.
+func schemaProps(t *testing.T, yaml string) map[string]any {
+	t.Helper()
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal([]byte(schemaBytesFor(t, yaml)), &schema))
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "schema must have properties")
+	return props
+}
+
+// TestParseVendorExtension verifies the @x-<keyword> directive is parsed and
+// attached to the preceding @param with its YAML-parsed value.
+func TestParseVendorExtension(t *testing.T) {
+	const yaml = `
+## @param {string} instanceType - Virtual Machine instance type.
+## @x-cozystack-options {source: instancetype}
+instanceType: "u1.medium"
+`
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+
+	var param *Raw
+	for i := range rows {
+		if rows[i].K == kParam && rows[i].Path[0] == "instanceType" {
+			param = &rows[i]
+		}
+	}
+	require.NotNil(t, param, "instanceType param should exist")
+	require.Equal(t, map[string]interface{}{
+		"x-cozystack-options": map[string]interface{}{"source": "instancetype"},
+	}, param.Extensions)
+}
+
+// TestVendorExtensionDoesNotCollideWithBuiltins ensures the @x- directive does
+// not swallow built-in directives like @param/@minimum (none start with "x-").
+func TestVendorExtensionDoesNotCollideWithBuiltins(t *testing.T) {
+	const yaml = `
+## @param {int} replicas - Replicas.
+## @minimum 1
+## @x-foo bar
+replicas: 1
+`
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+
+	var param *Raw
+	for i := range rows {
+		if rows[i].K == kParam && rows[i].Path[0] == "replicas" {
+			param = &rows[i]
+		}
+	}
+	require.NotNil(t, param)
+	require.NotNil(t, param.Minimum)
+	require.Equal(t, float64(1), *param.Minimum)
+	require.Equal(t, map[string]interface{}{"x-foo": "bar"}, param.Extensions)
+}
+
+// TestVendorExtensionOnParamInSchema checks an x-* key with an object value is
+// emitted onto a top-level property in the JSON schema.
+func TestVendorExtensionOnParamInSchema(t *testing.T) {
+	const yaml = `
+## @param {string} instanceType - Virtual Machine instance type.
+## @x-cozystack-options {source: instancetype}
+instanceType: "u1.medium"
+`
+	props := schemaProps(t, yaml)
+
+	it := props["instanceType"].(map[string]any)
+	require.Equal(t, map[string]any{"source": "instancetype"}, it["x-cozystack-options"])
+	require.Equal(t, "string", it["type"])
+}
+
+// TestVendorExtensionValueTypes checks object, array and scalar string values.
+func TestVendorExtensionValueTypes(t *testing.T) {
+	const yaml = `
+## @param {string} a - A.
+## @x-obj {source: gpu, kind: pci}
+a: ""
+
+## @param {string} b - B.
+## @x-list [{a: 1}, {b: 2}]
+b: ""
+
+## @param {string} c - C.
+## @x-str "hello world"
+c: ""
+`
+	props := schemaProps(t, yaml)
+
+	a := props["a"].(map[string]any)
+	require.Equal(t, map[string]any{"source": "gpu", "kind": "pci"}, a["x-obj"])
+
+	b := props["b"].(map[string]any)
+	require.Equal(t, []any{
+		map[string]any{"a": float64(1)},
+		map[string]any{"b": float64(2)},
+	}, b["x-list"])
+
+	c := props["c"].(map[string]any)
+	require.Equal(t, "hello world", c["x-str"])
+}
+
+// TestMultipleVendorExtensionsOnOneField checks several @x-* lines on one field.
+func TestMultipleVendorExtensionsOnOneField(t *testing.T) {
+	const yaml = `
+## @param {int} count - Count.
+## @x-foo-scalar 42
+## @x-foo-flag true
+## @x-foo-obj {a: 1}
+count: 1
+`
+	props := schemaProps(t, yaml)
+
+	c := props["count"].(map[string]any)
+	require.Equal(t, float64(42), c["x-foo-scalar"])
+	require.Equal(t, true, c["x-foo-flag"])
+	require.Equal(t, map[string]any{"a": float64(1)}, c["x-foo-obj"])
+}
+
+// TestVendorExtensionOnTypedefFieldPropagates verifies an x-* key declared on a
+// typedef @field appears wherever the type is used: directly, via []Type
+// (items.properties) and via map[string]Type (additionalProperties.properties).
+func TestVendorExtensionOnTypedefFieldPropagates(t *testing.T) {
+	const yaml = `
+## @typedef {struct} GPU - GPU device configuration.
+## @field {string} name - The name of the GPU resource to attach.
+## @x-cozystack-options {source: gpu}
+
+## @param {GPU} gpu - Single GPU.
+gpu: {}
+
+## @param {[]GPU} gpus - GPU list.
+gpus: []
+
+## @param {map[string]GPU} gpuMap - GPU map.
+gpuMap: {}
+`
+	props := schemaProps(t, yaml)
+
+	want := map[string]any{"source": "gpu"}
+
+	// Direct use: gpu.properties.name
+	gpu := props["gpu"].(map[string]any)
+	gpuName := gpu["properties"].(map[string]any)["name"].(map[string]any)
+	require.Equal(t, want, gpuName["x-cozystack-options"])
+
+	// Array use: gpus.items.properties.name
+	gpus := props["gpus"].(map[string]any)
+	items := gpus["items"].(map[string]any)
+	itemName := items["properties"].(map[string]any)["name"].(map[string]any)
+	require.Equal(t, want, itemName["x-cozystack-options"])
+
+	// Map use: gpuMap.additionalProperties.properties.name
+	gpuMap := props["gpuMap"].(map[string]any)
+	ap := gpuMap["additionalProperties"].(map[string]any)
+	apName := ap["properties"].(map[string]any)["name"].(map[string]any)
+	require.Equal(t, want, apName["x-cozystack-options"])
+}
+
+// TestVendorExtensionNotInGoTypes ensures vendor extensions never leak into the
+// generated Go types — they are schema-only.
+func TestVendorExtensionNotInGoTypes(t *testing.T) {
+	const yaml = `
+## @typedef {struct} GPU - GPU device configuration.
+## @field {string} name - The name of the GPU resource to attach.
+## @x-cozystack-options {source: gpu}
+
+## @param {string} instanceType - Instance type.
+## @x-cozystack-options {source: instancetype}
+instanceType: "u1.medium"
+
+## @param {[]GPU} gpus - GPU list.
+gpus: []
+`
+	tmp := writeTempFile(yaml)
+	defer os.Remove(tmp)
+
+	rows, err := Parse(tmp)
+	require.NoError(t, err)
+
+	root := Build(rows)
+	g := &gen{pkg: "values"}
+	formatted, _, err := g.Generate(root)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(formatted), "x-", "Go types must not contain vendor extension keys")
+	require.NotContains(t, string(formatted), "cozystack", "Go types must not contain extension values")
+}
+
+// orderFixtureYAML is a values.yaml whose params carry several constraints
+// whose JSONSchemaProps struct-field order differs from alphabetical order
+// (e.g. "type" precedes "maxLength"/"minLength"/"pattern", but alphabetically
+// "type" would sort last). It is shared by the order-preservation tests below.
+const orderFixtureYAML = `
+## @param {string} host - The hostname.
+## @maxLength 30
+## @minLength 3
+## @pattern ^[a-z.]+$
+host: "example.com"
+
+## @param {int} replicas - Number of replicas.
+## @maximum 10
+## @minimum 1
+replicas: 3
+`
+
+// TestSchemaKeyOrderPreservedWithoutExtensions asserts that, for an input with
+// NO @x- directive, the generated schema keeps each property's keys in
+// JSONSchemaProps struct-field order (NOT alphabetical). This guards against
+// the key-ordering regression where round-tripping through a Go map sorted
+// every object's keys alphabetically. It fails against the buggy code (which
+// emits "type" last) and passes once order is preserved.
+func TestSchemaKeyOrderPreservedWithoutExtensions(t *testing.T) {
+	got := schemaBytesFor(t, orderFixtureYAML)
+
+	const want = `{
+  "title": "Chart Values",
+  "type": "object",
+  "properties": {
+    "host": {
+      "description": "The hostname.",
+      "type": "string",
+      "maxLength": 30,
+      "minLength": 3,
+      "pattern": "^[a-z.]+$"
+    },
+    "replicas": {
+      "description": "Number of replicas.",
+      "type": "integer",
+      "maximum": 10,
+      "minimum": 1
+    }
+  }
+}
+`
+	require.Equal(t, want, got, "schema key order must follow struct order, not alphabetical")
+}
+
+// TestSchemaKeyOrderWithExtensionInsertedAtEnd asserts that adding a single
+// @x- directive to one field produces output identical to the no-extension
+// output EXCEPT for the injected x-* key, which is appended as the last key of
+// its object. Nothing else is reordered.
+func TestSchemaKeyOrderWithExtensionInsertedAtEnd(t *testing.T) {
+	const yamlWithExt = `
+## @param {string} host - The hostname.
+## @maxLength 30
+## @minLength 3
+## @pattern ^[a-z.]+$
+## @x-foo {source: dns}
+host: "example.com"
+
+## @param {int} replicas - Number of replicas.
+## @maximum 10
+## @minimum 1
+replicas: 3
+`
+	got := schemaBytesFor(t, yamlWithExt)
+
+	// The expectation is the no-extension golden with exactly the "x-foo"
+	// key appended at the end of the "host" object — pre-existing keys keep
+	// their original order and position.
+	const want = `{
+  "title": "Chart Values",
+  "type": "object",
+  "properties": {
+    "host": {
+      "description": "The hostname.",
+      "type": "string",
+      "maxLength": 30,
+      "minLength": 3,
+      "pattern": "^[a-z.]+$",
+      "x-foo": {
+        "source": "dns"
+      }
+    },
+    "replicas": {
+      "description": "Number of replicas.",
+      "type": "integer",
+      "maximum": 10,
+      "minimum": 1
+    }
+  }
+}
+`
+	require.Equal(t, want, got)
+
+	// And the diff versus the no-extension output is exactly the inserted key:
+	// stripping the injected x-foo block from the annotated output must
+	// reproduce the un-annotated output byte-for-byte.
+	const injected = `,
+      "x-foo": {
+        "source": "dns"
+      }`
+	require.Equal(t, schemaBytesFor(t, orderFixtureYAML),
+		strings.Replace(got, injected, "", 1),
+		"removing the injected x-foo key must reproduce the un-annotated output")
+}

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cozystack/cozyvalues-gen/internal/patterns"
 	"go.etcd.io/etcd/version"
+	"gopkg.in/yaml.v3"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
@@ -87,6 +88,11 @@ type Raw struct {
 	// Make the field required (no `[name]` brackets, no pointer) for full
 	// "immutable from creation" semantics.
 	Immutable bool
+
+	// Extensions holds arbitrary OpenAPI/JSON-Schema vendor extensions
+	// (keys starting with "x-") attached via @x-<keyword> directives.
+	// These are emitted verbatim into the JSON schema only, never into Go types.
+	Extensions map[string]interface{}
 }
 
 // JSDoc-like syntax patterns (using shared patterns from internal/patterns)
@@ -108,6 +114,9 @@ var (
 	reMinItems         = regexp.MustCompile(patterns.MinItemsPattern)
 	reMaxItems         = regexp.MustCompile(patterns.MaxItemsPattern)
 	reImmutable        = regexp.MustCompile(patterns.ImmutablePattern)
+
+	// Vendor extension directive (@x-<keyword>)
+	reVendorExtension = regexp.MustCompile(patterns.VendorExtensionPattern)
 
 	allConstraintREs = []*regexp.Regexp{
 		reMinimum, reMaximum, reExclusiveMinimum, reExclusiveMaximum,
@@ -312,6 +321,18 @@ func Parse(file string) ([]Raw, error) {
 				lastAnnotated.Immutable = true
 				continue
 			}
+			if m := reVendorExtension.FindStringSubmatch(line); m != nil {
+				key := m[1]
+				var value interface{}
+				if err := yaml.Unmarshal([]byte(m[2]), &value); err != nil {
+					return nil, fmt.Errorf("invalid @%s value %q for %q: %w", key, m[2], paramName, err)
+				}
+				if lastAnnotated.Extensions == nil {
+					lastAnnotated.Extensions = map[string]interface{}{}
+				}
+				lastAnnotated.Extensions[key] = value
+				continue
+			}
 		}
 
 		// Check for @param
@@ -498,6 +519,10 @@ type Node struct {
 	// Make the field required (no `[name]` brackets, no pointer) for full
 	// "immutable from creation" semantics.
 	Immutable bool
+
+	// Extensions holds arbitrary OpenAPI/JSON-Schema vendor extensions
+	// (keys starting with "x-"). Emitted into the JSON schema only.
+	Extensions map[string]interface{}
 }
 
 func newNode(name string, p *Node) *Node {
@@ -525,6 +550,7 @@ func copyConstraints(node *Node, raw *Raw) {
 	node.MinItems = raw.MinItems
 	node.MaxItems = raw.MaxItems
 	node.Immutable = raw.Immutable
+	node.Extensions = raw.Extensions
 }
 
 func Build(rows []Raw) *Node {
@@ -1224,6 +1250,275 @@ func CG(pkgDir string) ([]byte, error) {
 /*  Helm values JSON Schema                                                   */
 /* -------------------------------------------------------------------------- */
 
+// baseTypeName extracts the underlying named type from a type expression,
+// stripping pointer, slice and map wrappers (e.g. "[]*GPU" -> "GPU",
+// "map[string]NodeGroup" -> "NodeGroup", "*Config" -> "Config").
+func baseTypeName(expr string) string {
+	expr = strings.TrimSpace(expr)
+	expr = strings.TrimPrefix(expr, "*")
+	if strings.HasPrefix(expr, "[]") {
+		return baseTypeName(expr[2:])
+	}
+	if strings.HasPrefix(expr, "map[") {
+		if i := strings.Index(expr, "]"); i != -1 {
+			return baseTypeName(expr[i+1:])
+		}
+	}
+	return expr
+}
+
+// structuralChildren returns the child nodes that describe the object
+// properties of n. If n declares its own inline children they are used;
+// otherwise the node's type expression is resolved against the typedef
+// aliases so that extensions on typedef fields propagate wherever the type
+// is referenced (including via []Type and map[string]Type).
+func structuralChildren(n *Node, aliases map[string]*Node) map[string]*Node {
+	if n == nil {
+		return nil
+	}
+	if len(n.Child) > 0 {
+		return n.Child
+	}
+	base := baseTypeName(n.TypeExpr)
+	if base == "" {
+		return nil
+	}
+	if alias, ok := aliases[base]; ok && alias != n {
+		return alias.Child
+	}
+	return nil
+}
+
+// nodeSubtreeHasExtensions reports whether n or any node reachable from it
+// (through inline children or typedef aliases for direct / []Type /
+// map[string]Type references) carries a vendor extension. Used to decide
+// whether a property needs the order-preserving injection path at all; when
+// it does not, the property is emitted via plain json.MarshalIndent so output
+// stays byte-identical to the pre-extension generator.
+func nodeSubtreeHasExtensions(n *Node, aliases map[string]*Node, seen map[*Node]bool) bool {
+	if n == nil || seen[n] {
+		return false
+	}
+	seen[n] = true
+	if len(n.Extensions) > 0 {
+		return true
+	}
+	for _, child := range structuralChildren(n, aliases) {
+		if nodeSubtreeHasExtensions(child, aliases, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+// injectExtensions walks an order-preserving JSON schema node alongside its
+// corresponding Node, writing any vendor extensions (x-* keys) declared on
+// the node and recursively descending into nested object properties, array
+// items and map values. Extensions are emitted into the JSON schema only.
+//
+// Injected x-* keys are appended as the last key(s) of their object so that
+// all pre-existing keys keep their original relative order and position. This
+// guarantees byte-identical output to the pre-extension generator for any
+// schema that carries no extensions.
+func injectExtensions(schema *orderedMap, n *Node, aliases map[string]*Node) {
+	if schema == nil || n == nil {
+		return
+	}
+
+	for _, k := range sortedExtensionKeys(n.Extensions) {
+		schema.set(k, n.Extensions[k])
+	}
+
+	children := structuralChildren(n, aliases)
+	if children == nil {
+		return
+	}
+
+	// Object properties.
+	if props, ok := schema.get("properties").(*orderedMap); ok {
+		for name, child := range children {
+			if sub, ok := props.get(name).(*orderedMap); ok {
+				injectExtensions(sub, child, aliases)
+			}
+		}
+	}
+
+	// Array element type ([]Type) — children describe the element struct.
+	if items, ok := schema.get("items").(*orderedMap); ok {
+		injectExtensionsForElement(items, n, aliases)
+	}
+
+	// Map value type (map[string]Type) — children describe the value struct.
+	if ap, ok := schema.get("additionalProperties").(*orderedMap); ok {
+		injectExtensionsForElement(ap, n, aliases)
+	}
+}
+
+// injectExtensionsForElement injects extensions into the element schema of an
+// array or map, using the children that describe that element's struct.
+func injectExtensionsForElement(elem *orderedMap, n *Node, aliases map[string]*Node) {
+	children := structuralChildren(n, aliases)
+	if children == nil {
+		return
+	}
+	if props, ok := elem.get("properties").(*orderedMap); ok {
+		for name, child := range children {
+			if sub, ok := props.get(name).(*orderedMap); ok {
+				injectExtensions(sub, child, aliases)
+			}
+		}
+	}
+}
+
+// sortedExtensionKeys returns the keys of an Extensions map in a deterministic
+// (alphabetical) order so that multiple x-* keys on a single field are emitted
+// stably across runs.
+func sortedExtensionKeys(ext map[string]interface{}) []string {
+	if len(ext) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(ext))
+	for k := range ext {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Order-preserving JSON object representation                                */
+/* -------------------------------------------------------------------------- */
+
+// orderedMap is a JSON object whose key insertion order is preserved across an
+// Unmarshal/Marshal round-trip. It is used instead of map[string]interface{}
+// (which sorts keys alphabetically on marshal) so that the injected schema
+// stays byte-identical to direct json.Marshal of the source struct, except for
+// the appended vendor-extension (x-*) keys.
+type orderedMap struct {
+	keys   []string
+	values map[string]interface{}
+}
+
+func newOrderedMap() *orderedMap {
+	return &orderedMap{values: map[string]interface{}{}}
+}
+
+func (m *orderedMap) get(key string) interface{} {
+	if m == nil {
+		return nil
+	}
+	return m.values[key]
+}
+
+// set inserts or updates a key. New keys are appended, preserving order;
+// existing keys keep their original position.
+func (m *orderedMap) set(key string, value interface{}) {
+	if _, exists := m.values[key]; !exists {
+		m.keys = append(m.keys, key)
+	}
+	m.values[key] = value
+}
+
+// UnmarshalJSON decodes a JSON value into ordered structures. Objects become
+// *orderedMap (preserving key order), arrays become []interface{} whose object
+// elements are also *orderedMap, and scalars decode normally.
+func (m *orderedMap) UnmarshalJSON(data []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return fmt.Errorf("orderedMap: expected object, got %v", tok)
+	}
+	return m.decodeObject(dec)
+}
+
+func (m *orderedMap) decodeObject(dec *json.Decoder) error {
+	m.values = map[string]interface{}{}
+	m.keys = nil
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return fmt.Errorf("orderedMap: expected string key, got %v", keyTok)
+		}
+		val, err := decodeValue(dec)
+		if err != nil {
+			return err
+		}
+		m.set(key, val)
+	}
+	// Consume closing '}'.
+	if _, err := dec.Token(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// decodeValue decodes the next JSON value from dec, producing *orderedMap for
+// objects and []interface{} for arrays.
+func decodeValue(dec *json.Decoder) (interface{}, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if d, ok := tok.(json.Delim); ok {
+		switch d {
+		case '{':
+			child := newOrderedMap()
+			if err := child.decodeObject(dec); err != nil {
+				return nil, err
+			}
+			return child, nil
+		case '[':
+			arr := []interface{}{}
+			for dec.More() {
+				v, err := decodeValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, v)
+			}
+			// Consume closing ']'.
+			if _, err := dec.Token(); err != nil {
+				return nil, err
+			}
+			return arr, nil
+		}
+	}
+	return tok, nil
+}
+
+// MarshalJSON emits the object with keys in their preserved insertion order.
+func (m *orderedMap) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, k := range m.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		kb, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(kb)
+		buf.WriteByte(':')
+		vb, err := json.Marshal(m.values[k])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(vb)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
 func WriteValuesSchema(crdBytes []byte, outPath string) error {
 	return WriteValuesSchemaWithOrder(crdBytes, outPath, nil)
 }
@@ -1262,12 +1557,47 @@ func WriteValuesSchemaWithOrder(crdBytes []byte, outPath string, root *Node) err
 					}
 					first = false
 
-					propJSON, err := json.MarshalIndent(prop, "    ", "  ")
+					// Fast path: when this property's subtree carries no
+					// vendor extensions, emit it via plain MarshalIndent so
+					// the output is byte-identical to the pre-extension
+					// generator (JSONSchemaProps marshals in struct-field
+					// order, not alphabetical). Only properties that actually
+					// carry an x-* directive take the order-preserving
+					// injection path below.
+					if !nodeSubtreeHasExtensions(node, root.Child, map[*Node]bool{}) {
+						propJSON, err := json.MarshalIndent(prop, "    ", "  ")
+						if err != nil {
+							return err
+						}
+						buf.WriteString(fmt.Sprintf("    \"%s\": %s", key, string(propJSON)))
+						continue
+					}
+
+					// Injection path: marshal in struct-field order, round-trip
+					// through an order-preserving orderedMap (not a Go map,
+					// which sorts keys alphabetically), then append the x-*
+					// keys declared on this node and nested typedef fields
+					// without reordering any existing key.
+					rawJSON, err := json.Marshal(prop)
 					if err != nil {
 						return err
 					}
+					propMap := newOrderedMap()
+					if err := json.Unmarshal(rawJSON, propMap); err != nil {
+						return err
+					}
+					injectExtensions(propMap, node, root.Child)
 
-					buf.WriteString(fmt.Sprintf("    \"%s\": %s", key, string(propJSON)))
+					compact, err := json.Marshal(propMap)
+					if err != nil {
+						return err
+					}
+					var indented bytes.Buffer
+					if err := json.Indent(&indented, compact, "    ", "  "); err != nil {
+						return err
+					}
+
+					buf.WriteString(fmt.Sprintf("    \"%s\": %s", key, indented.String()))
 				}
 			}
 		}

--- a/internal/patterns/patterns.go
+++ b/internal/patterns/patterns.go
@@ -81,3 +81,10 @@ const MaxItemsPattern = `^#{1,}\s+@maxItems\s+(\d+)\s*$`
 // field required (omit `[name]` brackets and pointer markers).
 // No capture groups — presence indicates true.
 const ImmutablePattern = `^#{1,}\s+@immutable\s*$`
+
+// VendorExtensionPattern matches @x-<keyword> annotations carrying an arbitrary
+// OpenAPI/JSON-Schema vendor extension keyword. The matched key always starts
+// with "x-" (e.g. @x-cozystack-options) and never collides with the built-in
+// directives (@param/@field/@enum/@minimum/...) since none of those begin with "x-".
+// Groups: 1=full key (e.g. "x-cozystack-options"), 2=raw value text (parsed as YAML flow)
+const VendorExtensionPattern = `^#{1,}\s+@(x-[A-Za-z0-9][\w-]*)\s+(.+)$`


### PR DESCRIPTION
## What

Adds a vendor-neutral `@x-<keyword>` directive to the JSDoc-like annotation grammar parsed from Helm `values.yaml` comments. It lets a chart author attach any OpenAPI/JSON-Schema vendor extension keyword (any key starting with `x-`) to a `@param` or `@field`. The directive name carries the keyword, and the value is parsed as YAML flow:

```yaml
## @param {string} instanceType - Virtual Machine instance type.
## @x-cozystack-options {source: instancetype}
instanceType: "u1.medium"
```

emits into the generated JSON schema:

```json
"instanceType": { "type": "string", "description": "...", "x-cozystack-options": { "source": "instancetype" } }
```

Declared on a typedef field, the extension propagates everywhere the type is used — including `[]Type` (`items.properties`) and `map[string]Type` (`additionalProperties.properties`).

## Why

This is a generic `x-*` passthrough mechanism: any `x-foo-bar` key works and nothing is interpreted or hardcoded. The motivating consumer is cozystack's dynamic-dropdown UI, which reads `x-cozystack-options.source` from the schema to populate selectable values — but the directive is useful for any tool that consumes vendor extensions.

## Behavior

- Multiple `@x-*` lines are allowed on one field (distinct keys).
- Values may be objects, arrays or scalars.
- Extensions are emitted into `values.schema.json` **only**; they never leak into the generated Go types (`-g`), which remain pure data shapes. README generation is unaffected.

## Tests

Covers top-level `@param` extensions, typedef `@field` propagation through direct/array/map usage, object/array/scalar value types, multiple extensions per field, non-collision with built-in directives, and an assertion that no `x-` key appears in generated Go types. `go build`, `go test`, and `gofmt` are clean.
